### PR TITLE
Add ArgoCD GitHub notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ kubectl apply -f manifests/diun.yml
 kubectl apply -f manifests/database-backup.yml
 kubectl create namespace argocd
 kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+# update manifests/argocd-github-notifications.yml with your GitHub App data
+kubectl apply -f manifests/argocd-github-notifications.yml
 
 NAMESPACE="arc-systems"
 helm install arc \

--- a/manifests/argocd-github-notifications.yml
+++ b/manifests/argocd-github-notifications.yml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-notifications-secret
+  namespace: argocd
+stringData:
+  github-privateKey: |
+    -----BEGIN RSA PRIVATE KEY-----
+    <YOUR-PRIVATE-KEY>
+    -----END RSA PRIVATE KEY-----
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-notifications-cm
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: argocd-notifications-cm
+    app.kubernetes.io/part-of: argocd
+    notifications.argoproj.io/config: ""
+data:
+  service.github: |
+    appID: <APP-ID>
+    installationID: <INSTALLATION-ID>
+    privateKey: $github-privateKey
+  trigger.sync-operation-change: |
+    - when: app.status.operationState.phase in ['Running']
+      send: [github-commit-status]
+    - when: app.status.operationState.phase in ['Succeeded', 'Error', 'Failed']
+      send: [github-commit-status]
+  defaultTriggers: |
+    - sync-operation-change
+


### PR DESCRIPTION
## Summary
- add a manifest to configure GitHub notifications for ArgoCD
- document applying the new manifest during deployment

## Testing
- `pip install -r test/requirements.txt`
- `pytest -q test`

------
https://chatgpt.com/codex/tasks/task_e_683f73c5a17c8333bcf43b80ec206a95